### PR TITLE
Exceptions from commands get proper usage. Fixes #43.

### DIFF
--- a/jargo/src/main/java/se/softhouse/jargo/CommandLineParserInstance.java
+++ b/jargo/src/main/java/se/softhouse/jargo/CommandLineParserInstance.java
@@ -571,7 +571,15 @@ final class CommandLineParserInstance
 
 		void execute()
 		{
-			command.execute(args);
+			try
+			{
+				command.execute(args);
+			}
+			catch(ArgumentException exception)
+			{
+				exception.withUsage(argumentSettingsForInvokedCommand.usage());
+				throw exception;
+			}
 		}
 
 		@Override

--- a/jargo/src/test/java/se/softhouse/jargo/commands/CommandTest.java
+++ b/jargo/src/test/java/se/softhouse/jargo/commands/CommandTest.java
@@ -38,6 +38,7 @@ import se.softhouse.common.strings.Describers;
 import se.softhouse.jargo.Argument;
 import se.softhouse.jargo.ArgumentBuilder.CommandBuilder;
 import se.softhouse.jargo.ArgumentException;
+import se.softhouse.jargo.ArgumentExceptions;
 import se.softhouse.jargo.Arguments;
 import se.softhouse.jargo.Command;
 import se.softhouse.jargo.CommandLineParser;
@@ -833,6 +834,33 @@ public class CommandTest
 			assertThat(repeatable.numberOfCallsToExecute).isEqualTo(0);
 			assertThat(notRepeatable.numberOfCallsToExecute).isEqualTo(0);
 
+		}
+	}
+
+	@Test
+	public void testThatThrownArgumentExceptionsFromExecuteHasUsageAttachedToThem() throws Exception
+	{
+		try
+		{
+			CommandLineParser.withCommands(new Command(){
+
+				@Override
+				protected void execute(ParsedArguments parsedArguments)
+				{
+					throw ArgumentExceptions.withMessage("Catch me");
+				}
+
+				@Override
+				protected String commandName()
+				{
+					return "catcher";
+				}
+			}).parse("catcher");
+			fail("Thrown exception was suppressed");
+		}
+		catch(ArgumentException expected)
+		{
+			assertThat(expected.getMessageAndUsage()).isEqualTo(expected("exceptionFromCommand"));
 		}
 	}
 }

--- a/jargo/src/test/resources/jargo/usage_texts/exceptionFromCommand.txt
+++ b/jargo/src/test/resources/jargo/usage_texts/exceptionFromCommand.txt
@@ -1,0 +1,6 @@
+Catch me
+
+Usage: exceptionFromCommand [Arguments]
+
+Arguments:
+catcher 


### PR DESCRIPTION
If they are of the type ArgumentException that is.